### PR TITLE
10_as_casting.md: fix 256 bit representation

### DIFF
--- a/book/src/02_basic_calculator/10_as_casting.md
+++ b/book/src/02_basic_calculator/10_as_casting.md
@@ -46,7 +46,7 @@ To understand what happens, let's start by looking at how `256u16` is
 represented in memory, as a sequence of bits:
 
 ```text
- 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0
 |               |               |
 +---------------+---------------+
   First 8 bits    Last 8 bits


### PR DESCRIPTION
```
% python3
Python 3.11.2 (main, Mar 13 2023, 12:18:29) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 0b0_0_0_0_0_0_1_0_0_0_0_0_0_0_0_0
512
>>> 0b0_0_0_0_0_0_0_1_0_0_0_0_0_0_0_0
256
```

:)