### PR TITLE
Fix typo in 10_clone.md illustration

### DIFF
--- a/book/src/04_traits/10_clone.md
+++ b/book/src/04_traits/10_clone.md
@@ -75,7 +75,7 @@ Heap:  | H | e | l | l | o |
 When `let t = s.clone()` is executed, a whole new region is allocated on the heap to store a copy of the data:
 
 ```text
-                    s                                    s
+                    s                                    t
       +---------+--------+----------+      +---------+--------+----------+
 Stack | pointer | length | capacity |      | pointer | length | capacity |
       |  |      |   5    |    5     |      |  |      |   5    |    5     |


### PR DESCRIPTION
The clone() illustration shows two `s` values in the stack when one of them is the original `s` value which got cloned and the other one should be the new `t` value created from `s`.

Rename the second value from `s` to `t`.