### PR TITLE
fix spelling error

### DIFF
--- a/book/src/02_basic_calculator/06_while.md
+++ b/book/src/02_basic_calculator/06_while.md
@@ -30,7 +30,7 @@ while i <= 5 {
 }
 ```
 
-This will keep adding 1 to `sum` until `i` is no longer less than or equal to 5.
+This will keep adding 1 to `i` and `i` to `sum` until `i` is no longer less than or equal to 5.
 
 ## The `mut` keyword
 


### PR DESCRIPTION
Thank you for the great resource! As I was walking through, I noticed a small clarification issue regarding the `while` section in the book:

https://rust-exercises.com/02_basic_calculator/06_while

For the following code snippet
```rust
let sum = 0;
let i = 1;
// "while i is less than or equal to 5"
while i <= 5 {
    // `+=` is a shorthand for `sum = sum + i`
    sum += i;
    i += 1;
}
```


`This will keep adding 1 to sum until i is no longer less than or equal to 5.`

This isn't true. What's correct is

`This will keep adding 1 to i and i to sum until i is no longer less than or equal to 5.`

For what it's worth, the program isn't meant to compile as it comes right before introducing `mut`, I just thought that it's nice to be descriptively correct for clarity.