### PR TITLE
Fix typo in 05_ticket_v2/09_error_trait/[...] instructions

### DIFF
--- a/exercises/05_ticket_v2/09_error_trait/src/lib.rs
+++ b/exercises/05_ticket_v2/09_error_trait/src/lib.rs
@@ -11,7 +11,7 @@ enum TicketNewError {
 // TODO: `easy_ticket` should panic when the title is invalid, using the error message
 //   stored inside the relevant variant of the `TicketNewError` enum.
 //   When the description is invalid, instead, it should use a default description:
-//   "No description provided".
+//   "Description not provided".
 fn easy_ticket(title: String, description: String, status: Status) -> Ticket {
     todo!()
 }


### PR DESCRIPTION
The commented instructions of the exercise ask to use `No description provided` for the description field when calling `easy_ticket` with an invalid description argument. However, the unit test of that behavior compares the description to `Description not provided` instead.

Previous exercises in that part also use `Description not provided`.

Update the exercise 05_ticket_v2/09_error_trait instructions to use `Description not provided` as an expected default  description value when calling `easy_ticket` with no description instead of `No description provided`.