### PR TITLE
misunderstand the implements verb

### DIFF
--- a/book/src/04_traits/08_from.md
+++ b/book/src/04_traits/08_from.md
@@ -105,7 +105,7 @@ though the former bound is implicit.
 
 In [`std`'s documentation](https://doc.rust-lang.org/std/convert/trait.From.html#implementors) 
 you can see which `std` types implement the `From` trait.  
-You'll find that `&str` implements `From<&str> for String`. Thus, we can write:
+You'll find that `String` implements `From<&str> for String`. Thus, we can write:
 
 ```rust
 let title = String::from("A title");
@@ -129,7 +129,7 @@ where
 }
 ```
 
-If a type `T` implements `From<U>`, then `Into<U> for T` is automatically implemented. That's why
+If a type `U` implements `From<T>`, then `Into<U> for T` is automatically implemented. That's why
 we can write `let title = "A title".into();`.
 
 ## `.into()`

--- a/exercises/04_traits/08_from/src/lib.rs
+++ b/exercises/04_traits/08_from/src/lib.rs
@@ -1,4 +1,4 @@
-// TODO: Implement the `From<u32>` trait for the `WrappingU32` type to make `example` compile.
+// TODO: Implement the `From` trait for the `WrappingU32` type to make `example` compile.
 
 pub struct WrappingU32 {
     value: u32,

--- a/exercises/04_traits/08_from/src/lib.rs
+++ b/exercises/04_traits/08_from/src/lib.rs
@@ -1,4 +1,4 @@
-// TODO: Implement the `From` trait for the `u32` type to make `example` compile.
+// TODO: Implement the `From<u32>` trait for the `WrappingU32` type to make `example` compile.
 
 pub struct WrappingU32 {
     value: u32,


### PR DESCRIPTION
misusing the verb `implements`.
impl for T means T implement something (maybe a trait).

```rust
impl<T, U> Into<U> for T
where
    U: From<T>,
```
the  trait bounds `U: From<T>` mean U implements From<T> trait.