### PR TITLE
Fix a typo in 03_ticket_v1/08_stack

### DIFF
--- a/book/src/03_ticket_v1/08_stack.md
+++ b/book/src/03_ticket_v1/08_stack.md
@@ -45,7 +45,7 @@ using the [`std::mem::size_of`](https://doc.rust-lang.org/std/mem/fn.size_of.htm
 For a `u8`, for example:
 
 ```rust
-// We'll explain this funny-looking syntax (`::<String>`) later on.
+// We'll explain this funny-looking syntax (`::<u8>`) later on.
 // Ignore it for now.
 assert_eq!(std::mem::size_of::<u8>(), 1);
 ```


### PR DESCRIPTION
The type argument of `size_of` is `<u8>` instead of `<String>`.