### PR TITLE
Add i32/u32 suffix for numeric literals in 04_traits/01_trait

### DIFF
--- a/exercises/04_traits/01_trait/src/lib.rs
+++ b/exercises/04_traits/01_trait/src/lib.rs
@@ -9,15 +9,15 @@ mod tests {
 
     #[test]
     fn test_u32_is_even() {
-        assert!(42.is_even());
-        assert!(!43.is_even());
+        assert!(42u32.is_even());
+        assert!(!43u32.is_even());
     }
 
     #[test]
     fn test_i32_is_even() {
-        assert!(42.is_even());
-        assert!(!43.is_even());
-        assert!(0.is_even());
-        assert!(!(-1).is_even());
+        assert!(42i32.is_even());
+        assert!(!43i32.is_even());
+        assert!(0i32.is_even());
+        assert!(!(-1i32).is_even());
     }
 }


### PR DESCRIPTION
Without an explicit suffix, the compiler is able to use the i32
implementation without the need for an u32 implementation.
