### PR TITLE
07_threads/10_patch: Check status field value after patch

### DIFF
--- a/exercises/07_threads/10_patch/tests/check.rs
+++ b/exercises/07_threads/10_patch/tests/check.rs
@@ -26,5 +26,6 @@ fn works() {
     client.update(patch).unwrap();
 
     let ticket = client.get(ticket_id).unwrap().unwrap();
-    assert_eq!(ticket_id, ticket.id);
+    assert_eq!(ticket.id, ticket_id);
+    assert_eq!(ticket.status, Status::InProgress);
 }


### PR DESCRIPTION
We want to check whether the ticket's `status` field was actually patched to `Status::InProgress`.