### PR TITLE
Change part of speech for syntax

### DIFF
--- a/book/src/04_traits/03_operator_overloading.md
+++ b/book/src/04_traits/03_operator_overloading.md
@@ -28,7 +28,7 @@ pub trait PartialEq {
 ```
 
 When you write `x == y` the compiler will look for an implementation of the `PartialEq` trait for the types of `x` and `y`
-and replace `x == y` with `x.eq(y)`. It's syntax sugar!
+and replace `x == y` with `x.eq(y)`. It's syntactic sugar!
 
 This is the correspondence for the main operators:
 


### PR DESCRIPTION
While I do not think it is confusing as is, I think technically syntax is being used as an adjective because sugar is the noun in the sentence so the adjective version of syntax is syntactic and that's why I am proposing changing it.