### PR TITLE
Specified type to prevent compile error

### DIFF
--- a/exercises/02_basic_calculator/09_saturating/src/lib.rs
+++ b/exercises/02_basic_calculator/09_saturating/src/lib.rs
@@ -1,5 +1,5 @@
 pub fn factorial(n: u32) -> u32 {
-    let mut result = 1;
+    let mut result: u32 = 1;
     for i in 1..=n {
         // Use saturating multiplication to stop at the maximum value of u32
         // rather than overflowing and wrapping around


### PR DESCRIPTION
By specifing the integer type, we avoid the compile error:

error[E0689]: can't call method `saturating_mul` on ambiguous numeric type `{integer}`

rustc version 1.78.0 (9b00956e5 2024-04-29)