### PR TITLE
Update references in `book/src/04_traits`

### DIFF
--- a/book/src/04_traits/05_trait_bounds.md
+++ b/book/src/04_traits/05_trait_bounds.md
@@ -152,3 +152,7 @@ The rationale is the same as for [explicit type annotations on function paramete
 each function signature is a contract between the caller and the callee, and the terms must be explicitly stated. 
 This allows for better error messages, better documentation, less unintentional breakages across versions, 
 and faster compilation times.
+
+## References
+
+- The exercise for this section is located in `exercises/04_traits/05_trait_bounds`

--- a/book/src/04_traits/06_str_slice.md
+++ b/book/src/04_traits/06_str_slice.md
@@ -117,4 +117,4 @@ bunch of text data and that a subset of it matches what you need, therefore you'
 
 ## References
 
-- The exercise for this section is located in `exercises/04_traits/05_str_slice`
+- The exercise for this section is located in `exercises/04_traits/06_str_slice`

--- a/book/src/04_traits/07_deref.md
+++ b/book/src/04_traits/07_deref.md
@@ -92,4 +92,4 @@ We'll examine later in the course the "safest" use cases for deref coercion: sma
 
 ## References
 
-- The exercise for this section is located in `exercises/04_traits/06_deref`
+- The exercise for this section is located in `exercises/04_traits/07_deref`

--- a/book/src/04_traits/08_sized.md
+++ b/book/src/04_traits/08_sized.md
@@ -80,4 +80,4 @@ and one for the length.
 
 ## References
 
-- The exercise for this section is located in `exercises/04_traits/07_sized`
+- The exercise for this section is located in `exercises/04_traits/08_sized`

--- a/book/src/04_traits/09_from.md
+++ b/book/src/04_traits/09_from.md
@@ -130,4 +130,4 @@ In most cases, the target type is either:
 
 ## References
 
-- The exercise for this section is located in `exercises/04_traits/08_from`
+- The exercise for this section is located in `exercises/04_traits/09_from`

--- a/book/src/04_traits/10_assoc_vs_generic.md
+++ b/book/src/04_traits/10_assoc_vs_generic.md
@@ -115,4 +115,4 @@ To recap:
 
 ## References
 
-- The exercise for this section is located in `exercises/04_traits/09_assoc_vs_generic`
+- The exercise for this section is located in `exercises/04_traits/10_assoc_vs_generic`

--- a/book/src/04_traits/11_clone.md
+++ b/book/src/04_traits/11_clone.md
@@ -108,4 +108,4 @@ Remember that you can use `cargo expand` (or your IDE) to explore the code gener
 
 ## References
 
-- The exercise for this section is located in `exercises/04_traits/10_clone`
+- The exercise for this section is located in `exercises/04_traits/11_clone`

--- a/book/src/04_traits/12_copy.md
+++ b/book/src/04_traits/12_copy.md
@@ -114,4 +114,4 @@ struct MyStruct {
 
 ## References
 
-- The exercise for this section is located in `exercises/04_traits/11_copy`
+- The exercise for this section is located in `exercises/04_traits/12_copy`

--- a/book/src/04_traits/13_drop.md
+++ b/book/src/04_traits/13_drop.md
@@ -53,4 +53,4 @@ error[E0184]: the trait `Copy` cannot be implemented for this type; the type has
 
 ## References
 
-- The exercise for this section is located in `exercises/04_traits/12_drop`
+- The exercise for this section is located in `exercises/04_traits/13_drop`

--- a/book/src/04_traits/14_outro.md
+++ b/book/src/04_traits/14_outro.md
@@ -9,4 +9,4 @@ You'll have minimal guidance this time—just the exercise description and the t
 
 ## References
 
-- The exercise for this section is located in `exercises/04_traits/13_outro` 
+- The exercise for this section is located in `exercises/04_traits/14_outro` 


### PR DESCRIPTION
- Add 'References' section in `book/src/04_traits/05_trait_bounds.md` for consistency
- Update paths for exercises

Related: https://github.com/mainmatter/100-exercises-to-learn-rust/commit/453d8030e5b4c6a43cf91b2f075b28f6c2d37ec2