### PR TITLE
Update variant name

### DIFF
--- a/book/src/05_ticket_v2/09_error_trait.md
+++ b/book/src/05_ticket_v2/09_error_trait.md
@@ -2,7 +2,7 @@
 
 ## Error reporting
 
-In the previous exercise you had to destructure the `InvalidTitle` variant to extract the error message and
+In the previous exercise you had to destructure the `TitleError` variant to extract the error message and
 pass it to the `panic!` macro.\
 This is a (rudimentary) example of **error reporting**: transforming an error type into a representation that can be
 shown to a user, a service operator, or a developer.


### PR DESCRIPTION
The name of the variant used in the previous exercise is `TitleError`, not `InvalidTitle` (https://github.com/mainmatter/100-exercises-to-learn-rust/blob/solutions/exercises/05_ticket_v2/08_error_enums/src/lib.rs#L20)