### PR TITLE
Change execution unit name

### DIFF
--- a/book/src/08_futures/02_spawn.md
+++ b/book/src/08_futures/02_spawn.md
@@ -99,7 +99,7 @@ pub async fn run() {
         if let Ok(reason) = e.try_into_panic() {
             // The task has panicked
             // We resume unwinding the panic,
-            // thus propagating it to the current thread
+            // thus propagating it to the current task
             panic::resume_unwind(reason);
         }
     }


### PR DESCRIPTION
I'm not very sure of this one but based on my understanding it would propagate the panic to the current task which would again be caught by the executor