### PR TITLE
Prefer borrowing over ownership

### DIFF
--- a/exercises/06_ticket_management/15_hashmap/src/lib.rs
+++ b/exercises/06_ticket_management/15_hashmap/src/lib.rs
@@ -56,12 +56,12 @@ impl TicketStore {
         id
     }
 
-    pub fn get(&self, id: TicketId) -> Option<&Ticket> {
-        self.tickets.get(&id)
+    pub fn get(&self, id: &TicketId) -> Option<&Ticket> {
+        self.tickets.get(id)
     }
 
-    pub fn get_mut(&mut self, id: TicketId) -> Option<&mut Ticket> {
-        self.tickets.get_mut(&id)
+    pub fn get_mut(&mut self, id: &TicketId) -> Option<&mut Ticket> {
+        self.tickets.get_mut(id)
     }
 }
 
@@ -69,7 +69,7 @@ impl Index<TicketId> for TicketStore {
     type Output = Ticket;
 
     fn index(&self, index: TicketId) -> &Self::Output {
-        self.get(index).unwrap()
+        &self[&index]
     }
 }
 
@@ -77,19 +77,19 @@ impl Index<&TicketId> for TicketStore {
     type Output = Ticket;
 
     fn index(&self, index: &TicketId) -> &Self::Output {
-        &self[*index]
+        self.get(index).unwrap()
     }
 }
 
 impl IndexMut<TicketId> for TicketStore {
     fn index_mut(&mut self, index: TicketId) -> &mut Self::Output {
-        self.get_mut(index).unwrap()
+        &mut self[&index]
     }
 }
 
 impl IndexMut<&TicketId> for TicketStore {
     fn index_mut(&mut self, index: &TicketId) -> &mut Self::Output {
-        &mut self[*index]
+        self.get_mut(index).unwrap()
     }
 }
 

--- a/exercises/06_ticket_management/16_btreemap/src/lib.rs
+++ b/exercises/06_ticket_management/16_btreemap/src/lib.rs
@@ -58,12 +58,12 @@ impl TicketStore {
         id
     }
 
-    pub fn get(&self, id: TicketId) -> Option<&Ticket> {
-        self.tickets.get(&id)
+    pub fn get(&self, id: &TicketId) -> Option<&Ticket> {
+        self.tickets.get(id)
     }
 
-    pub fn get_mut(&mut self, id: TicketId) -> Option<&mut Ticket> {
-        self.tickets.get_mut(&id)
+    pub fn get_mut(&mut self, id: &TicketId) -> Option<&mut Ticket> {
+        self.tickets.get_mut(id)
     }
 }
 
@@ -71,7 +71,7 @@ impl Index<TicketId> for TicketStore {
     type Output = Ticket;
 
     fn index(&self, index: TicketId) -> &Self::Output {
-        self.get(index).unwrap()
+        &self[&index]
     }
 }
 
@@ -79,19 +79,19 @@ impl Index<&TicketId> for TicketStore {
     type Output = Ticket;
 
     fn index(&self, index: &TicketId) -> &Self::Output {
-        &self[*index]
+        self.get(index).unwrap()
     }
 }
 
 impl IndexMut<TicketId> for TicketStore {
     fn index_mut(&mut self, index: TicketId) -> &mut Self::Output {
-        self.get_mut(index).unwrap()
+        &mut self[&index]
     }
 }
 
 impl IndexMut<&TicketId> for TicketStore {
     fn index_mut(&mut self, index: &TicketId) -> &mut Self::Output {
-        &mut self[*index]
+        self.get_mut(index).unwrap()
     }
 }
 


### PR DESCRIPTION
Hi, I am Dario from [hiop](https://hiop.io/).

First of all, thank you for this repo.
This repo is gold for startups like us who want to build rust skills in our teams.

I was following the exercises you kindly provided and when I had to deal with 06x(15, 16), I proposed a different solution.

The part involved is the following:
- https://github.com/mainmatter/100-exercises-to-learn-rust/blob/38dea384537077225888f3487be83501386cd851/exercises/06_ticket_management/15_hashmap/src/lib.rs#L59-L65

Following the principle of _Preferring borrowing over ownership_, the whole point is that the `get` and `get_mut` methods for `TicketStore` IMHO should take a reference as input, since the `HashMap` and `BTreeMap` ones don't require ownership

- https://github.com/dariocurr/100-exercises-to-learn-rust/blob/f3ba66fe5b8ca873ba2e12b6e5b135f61c1c22f6/exercises/06_ticket_management/15_hashmap/src/lib.rs#L59-L65

What's your take on this? 

Linked to #63 