### PR TITLE
Better example for ownership transfer using String

### DIFF
--- a/book/src/03_ticket_v1/06_ownership.md
+++ b/book/src/03_ticket_v1/06_ownership.md
@@ -95,8 +95,8 @@ Ownership can be transferred.
 If you own a value, for example, you can transfer ownership to another variable:
 
 ```rust
-let a = 42; // <--- `a` is the owner of the value `42`
-let b = a;  // <--- `b` is now the owner of the value `42`
+let a = "hello, world".into(); // <--- `a` is the owner of the String
+let b = a;  // <--- `b` is now the owner of the String
 ```
 
 Rust's ownership system is baked into the type system: each function has to declare in its signature

--- a/book/src/03_ticket_v1/06_ownership.md
+++ b/book/src/03_ticket_v1/06_ownership.md
@@ -95,7 +95,7 @@ Ownership can be transferred.
 If you own a value, for example, you can transfer ownership to another variable:
 
 ```rust
-let a = "hello, world".into(); // <--- `a` is the owner of the String
+let a = "hello, world".to_string(); // <--- `a` is the owner of the String
 let b = a;  // <--- `b` is now the owner of the String
 ```
 


### PR DESCRIPTION
I think the ownership transfer bits can use a better example.

The value 42 is just copied into the new variable, so this example does demonstrate the functioning of the borrow checker.

    let a = 42;
    let b = a;
    println!("a is {}, b is {}", a, b);

Outputs

    a is 42, b is 42

But on changing to a `String` value

    let a = String::from("hello");
    let b = a;
    println!("a is {}, b is {}", a, b);

We get a better demonstration
```
   Compiling my-project v0.1.0 (/Users/keshav/my-project)
error[E0382]: borrow of moved value: `a`
 --> src/main.rs:8:34
  |
6 |     let a = String::from("hello");
  |         - move occurs because `a` has type `String`, which does not implement the `Copy` trait
7 |     let b = a;
  |             - value moved here
8 |     println!("a is {}, b is {}", a, b);
  |                                  ^ value borrowed here after move
```

I really like your approach to learning Rust. I crashed out of reading the book 2 times. But I think it's much better as a companion to this way of learning