### PR TITLE
Add message about watching `wr`s progress

### DIFF
--- a/book/src/01_intro/00_welcome.md
+++ b/book/src/01_intro/00_welcome.md
@@ -86,6 +86,19 @@ Don't move on to the next section until you've solved the exercise for the curre
 > We recommend committing your solutions to Git as you progress through the course,
 > so you can easily track your progress and "restart" from a known point if needed.
 
+(Optional)
+If you want `wr` to be re-run each time you make a change, you can install cargo watch:
+
+```bash
+cargo install cargo-watch
+```
+
+You can use cargo watch like this:
+
+```bash
+cargo watch -- wr
+```
+
 Enjoy the course!
 
 ## Author


### PR DESCRIPTION
I tried `watch wr`, and it produced no output. Fortunately, rust's cargo-watch library works correctly.

I used it in a split terminal in VS Code with the keep going flag, which allows me to control-click on each new exercise as it fails:

![image](https://github.com/mainmatter/100-exercises-to-learn-rust/assets/3342777/ea9a7c56-a2b0-4d27-9d5b-e366601bbf26)