### PR TITLE
Update 07_setters.md: Add missing mut

### DIFF
--- a/book/src/03_ticket_v1/07_setters.md
+++ b/book/src/03_ticket_v1/07_setters.md
@@ -29,10 +29,10 @@ are respected (i.e. you can't set a `Ticket`'s title to an empty string).
 
 There are two common ways to implement setters in Rust:
 
-- Taking `self` as input.
+- Taking `mut self` as input.
 - Taking `&mut self` as input.
 
-### Taking `self` as input
+### Taking `mut self` as input
 
 The first approach looks like this:
 
@@ -50,7 +50,7 @@ It takes ownership of `self`, changes the title, and returns the modified `Ticke
 This is how you'd use it:
 
 ```rust
-let ticket = Ticket::new("Title".into(), "Description".into(), "To-Do".into());
+let mut ticket = Ticket::new("Title".into(), "Description".into(), "To-Do".into());
 let ticket = ticket.set_title("New title".into());
 ```
 


### PR DESCRIPTION
Hi, I noticed that `mut` was missing in 3 places even though the method in the example used `mut self`, this could be confusing since a setter would always take a `mut self` instead of an immutable one.