### PR TITLE
fix(typo): remove a module name in comments

### DIFF
--- a/exercises/03_ticket_v1/04_visibility/src/lib.rs
+++ b/exercises/03_ticket_v1/04_visibility/src/lib.rs
@@ -48,7 +48,7 @@ mod tests {
 
         // You should be seeing this error when trying to run this exercise:
         //
-        // error[E0616]: field `description` of struct `encapsulation::ticket::Ticket` is private
+        // error[E0616]: field `description` of struct `Ticket` is private
         //    |
         //    |              assert_eq!(ticket.description, "A description");
         //    |                         ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The output of the compiler does not include the module name of the `Ticket` struct and the root module of this exercise is `visibility` rather than `encapsulation` which is the root module of the next exercise.