### PR TITLE
Remove pub visibility on `server()`

### DIFF
--- a/exercises/07_threads/08_client/src/lib.rs
+++ b/exercises/07_threads/08_client/src/lib.rs
@@ -38,7 +38,7 @@ enum Command {
     },
 }
 
-pub fn server(receiver: Receiver<Command>) {
+fn server(receiver: Receiver<Command>) {
     let mut store = TicketStore::new();
     loop {
         match receiver.recv() {


### PR DESCRIPTION
The argument has a private type. This gets rid of the `private_interfaces` warning.