### PR TITLE
Fix reference to supertrait syntax in 09_error_trait.md

### DIFF
--- a/book/src/05_ticket_v2/09_error_trait.md
+++ b/book/src/05_ticket_v2/09_error_trait.md
@@ -22,7 +22,7 @@ that implements the `Error` trait.
 pub trait Error: Debug + Display {}
 ```
 
-You might recall the `:` syntax from [the `Sized` trait](../04_traits/08_sized.md)—it's used to specify **supertraits**.
+You might recall the `:` syntax from [the `From` trait](../04_traits/09_from.md#supertrait--subtrait)—it's used to specify **supertraits**.
 For `Error`, there are two supertraits: `Debug` and `Display`. If a type wants to implement `Error`, it must also
 implement `Debug` and `Display`.
 


### PR DESCRIPTION
The [Error trait](https://rust-exercises.com/100-exercises/05_ticket_v2/09_error_trait.html?highlight=supertrait#the-error-trait) chapter states that the reader may recall the supertrait syntax from the [Sized trait](https://rust-exercises.com/100-exercises/04_traits/08_sized) chapter. Actually the syntax is introduced in the [From and Into](https://rust-exercises.com/100-exercises/04_traits/09_from) chapter instead. This PR amends the text accordingly.