### PR TITLE
Fix remove redundant clone

### DIFF
--- a/exercises/05_ticket_v2/09_error_trait/src/lib.rs
+++ b/exercises/05_ticket_v2/09_error_trait/src/lib.rs
@@ -25,7 +25,7 @@ impl std::error::Error for TicketNewError {}
 //   When the description is invalid, instead, it should use a default description:
 //   "Description not provided".
 fn easy_ticket(title: String, description: String, status: Status) -> Ticket {
-    match Ticket::new(title.clone(), description.clone(), status.clone()) {
+    match Ticket::new(title.clone(), description, status.clone()) {
         Ok(ticket) => ticket,
         Err(err) => match err {
             TicketNewError::TitleError(_) => panic!("{err}"),


### PR DESCRIPTION
Following up on #139, for removing extra `.clone()` calls.