### PR TITLE
Remove duplicated mention of slices in 00_intro.md

### DIFF
--- a/book/src/06_ticket_management/00_intro.md
+++ b/book/src/06_ticket_management/00_intro.md
@@ -8,7 +8,7 @@ store and retrieve tickets.
 The task will give us an opportunity to explore new Rust concepts, such as:
 
 - Stack-allocated arrays
-- `Vec`, a growable array type, and slices
+- `Vec`, a growable array type
 - `Iterator` and `IntoIterator`, for iterating over collections
 - Slices (`&[T]`), to work with parts of a collection
 - Lifetimes, to describe how long references are valid


### PR DESCRIPTION
Slices are already mentioned in bullet point 4, so they can be removed from bullet point 2.