### PR TITLE
Don't omit macros from PDF and ePUB versions

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -22,6 +22,9 @@ git-repository-url = "https://github.com/mainmatter/100-exercises-to-learn-rust"
 optional = true
 hosted-html = "https://rust-exercises.com/100-exercises/"
 
+[output.pandoc.code]
+show-hidden-lines = true
+
 [output.pandoc.profile.pdf] # options to pass to Pandoc (see https://pandoc.org/MANUAL.html)
 output-file = "100-exercises-to-learn-rust.pdf"
 to = "latex"


### PR DESCRIPTION
Without this attribute, all lines starting with `#` are stripped away when going through `mdbook-pandoc`. In particular, all macros, as you can see in the code snippets for section 4.4 on derive macros.