### PR TITLE
add missing ; to return ()

### DIFF
--- a/exercises/03_ticket_v1/07_setters/src/lib.rs
+++ b/exercises/03_ticket_v1/07_setters/src/lib.rs
@@ -80,14 +80,14 @@ mod tests {
     #[should_panic(expected = "Title cannot be longer than 50 bytes")]
     fn title_cannot_be_longer_than_fifty_chars() {
         Ticket::new(valid_title(), valid_description(), "To-Do".into())
-            .set_title(overly_long_title())
+            .set_title(overly_long_title());
     }
 
     #[test]
     #[should_panic(expected = "Description cannot be longer than 500 bytes")]
     fn description_cannot_be_longer_than_500_chars() {
         Ticket::new(valid_title(), valid_description(), "To-Do".into())
-            .set_description(overly_long_description())
+            .set_description(overly_long_description());
     }
 
     #[test]


### PR DESCRIPTION
Note that all other remaining test functions do suppress return value with an explicit semicolon. However these two don't and the following (I guess still valid?) solution

```rust
    pub fn set_title(&mut self, title: String) -> &Self {
        if title.is_empty() {
            panic!("Title cannot be empty");
        } else if title.len() > 50 {
            panic!("Title cannot be longer than 50 bytes");
        }
        self.title = title;
        return self
    }
```

throws an error:
```
   Compiling setters v0.1.0 (/home/kalmar/local/rust/100-exercises-to-learn-rust/exercises/03_ticket_v1/07_setters)
error[E0308]: mismatched types
   --> exercises/03_ticket_v1/07_setters/src/lib.rs:110:9
    |
110 | /         Ticket::new(valid_title(), valid_description(), "To-Do".into())
111 | |             .set_title(overly_long_title())
    | |___________________________________________^ expected `()`, found `&Ticket`
    |
help: consider using a semicolon here
    |
111 |             .set_title(overly_long_title());
    |                                            +
help: try adding a return type
    |
109 |     fn title_cannot_be_longer_than_fifty_chars() -> &Ticket {
    |                                                  ++++++++++

For more information about this error, try `rustc --explain E0308`.
error: could not compile `setters` (lib test) due to 1 previous error
```
