### PR TITLE
Update reference from Rustonomicon to Rust Reference

### DIFF
--- a/exercises/03_ticket_v1/09_heap/src/lib.rs
+++ b/exercises/03_ticket_v1/09_heap/src/lib.rs
@@ -21,8 +21,8 @@ mod tests {
         // This is a tricky question!
         // The "intuitive" answer happens to be the correct answer this time,
         // but, in general, the memory layout of structs is a more complex topic.
-        // If you're curious, check out the "Data layout" section of the Rustonomicon
-        // https://doc.rust-lang.org/nomicon/data.html for more information.
+        // If you're curious, check out the "Type layout" section of The Rust Reference
+        // https://doc.rust-lang.org/reference/type-layout.html for more information.
         assert_eq!(size_of::<Ticket>(), todo!());
     }
 }


### PR DESCRIPTION
The exercise refers to the "Data layout" section of the Rustonomicon, but now that section claims itself deprecated and redirects to the "Type layout" section of The Rust Reference.