### PR TITLE
05_ticket_v2 outro: correct comment on title

### DIFF
--- a/exercises/05_ticket_v2/15_outro/src/title.rs
+++ b/exercises/05_ticket_v2/15_outro/src/title.rs
@@ -1,5 +1,5 @@
 // TODO: Implement `TryFrom<String>` and `TryFrom<&str>` for the `TicketTitle` type,
-//   enforcing that the title is not empty and is not longer than 50 characters.
+//   enforcing that the title is not empty and is not longer than 50 bytes.
 //   Implement the traits required to make the tests pass too.
 
 pub struct TicketTitle(String);


### PR DESCRIPTION
Characters was meant to be bytes, this was missed in a former refactoring