### PR TITLE
Fix docstring: "when converted to `u8`"

### DIFF
--- a/exercises/02_basic_calculator/10_as_casting/src/lib.rs
+++ b/exercises/02_basic_calculator/10_as_casting/src/lib.rs
@@ -23,7 +23,7 @@ mod tests {
 
         // You could solve this by using exactly the same expression as above,
         // but that would defeat the purpose of the exercise. Instead, use a genuine
-        // `i8` value that is equivalent to `255` when converted from `u8`.
+        // `i8` value that is equivalent to `255` when converted to `u8`.
         let y: i8 = todo!();
 
         assert_eq!(x, y);


### PR DESCRIPTION
Fixed docstring