### PR TITLE
chore(ci): re-create book artifacts at the beginning of each month

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+  schedule:
+    # First day of a month
+    - cron: '0 0 1 * *'
 
 jobs:
   build:


### PR DESCRIPTION
- Adds a workflow_dispatch trigger so the CI can be manually triggered
- Adds a schedule trigger to run at the beginning of each month.

Github actions artifacts expire after 90 days. So we'll periodically refresh them.
For use in https://github.com/mainmatter/rust-exercises.com

Same as https://github.com/mainmatter/rust-python-interoperability/pull/9 and https://github.com/mainmatter/rust-advanced-testing-workshop/pull/6