### PR TITLE
Update lib.rs: made fn server non-public

### DIFF
--- a/exercises/07_threads/09_bounded/src/lib.rs
+++ b/exercises/07_threads/09_bounded/src/lib.rs
@@ -56,7 +56,7 @@ enum Command {
     },
 }
 
-pub fn server(receiver: Receiver<Command>) {
+fn server(receiver: Receiver<Command>) {
     let mut store = TicketStore::new();
     loop {
         match receiver.recv() {


### PR DESCRIPTION
`fn server()` does not need to be public (and will raise a warning if it is), similarly to how it already is in exercise `08_client`.