### PR TITLE
Warn about the risks of using catch-all patterns

### DIFF
--- a/book/src/05_ticket_v2/02_match.md
+++ b/book/src/05_ticket_v2/02_match.md
@@ -73,5 +73,5 @@ The `_` pattern matches anything that wasn't matched by the previous patterns.
 By using this catch-all pattern, you _won't_ get the benefits of compiler-driven refactoring.\
 If you add a new enum variant, the compiler _won't_ tell you that you're not handling it.
 
-In general, prefer to avoid catch-all patterns unless you're really sure future new variants should be handled the same way.
+If you're keen on correctness, avoid using catch-alls. Leverage the compiler to re-examine all matching sites and determine how new enum variants should be handled.
 </div>


### PR DESCRIPTION
This may not be obvious to people who have never experienced compiler-driven refactoring before, and feels worth calling out.