### PR TITLE
refactor: illustrate borrowing from environment

### DIFF
--- a/exercises/07_threads/04_scoped_threads/src/lib.rs
+++ b/exercises/07_threads/04_scoped_threads/src/lib.rs
@@ -5,12 +5,14 @@
 pub fn sum(v: Vec<i32>) -> i32 {
     let mid = v.len() / 2;
     let (left, right) = v.split_at(mid);
+    let mut left_sum = 0;
+    let mut right_sum = 0;
 
     std::thread::scope(|s| {
-        let left = s.spawn(|| left.iter().sum::<i32>());
-        let right = s.spawn(|| right.iter().sum::<i32>());
-        left.join().unwrap() + right.join().unwrap()
-    })
+        s.spawn(|| left_sum = left.iter().sum::<i32>());
+        s.spawn(|| right_sum = right.iter().sum::<i32>());
+    });
+    left_sum + right_sum
 }
 
 #[cfg(test)]


### PR DESCRIPTION
adding variables that get used within the scoped threads make more sense with the content of the chapter and using a different way interact with the environment than joining the threads