### PR TITLE
Update 12_copy.md

### DIFF
--- a/book/src/04_traits/12_copy.md
+++ b/book/src/04_traits/12_copy.md
@@ -108,6 +108,7 @@ You can just derive it, like this:
 ```rust
 #[derive(Copy, Clone)]
 struct MyStruct {
-    field: u32,
+    field_1: u32,
+    field_2: u32,
 }
 ```


### PR DESCRIPTION
Sorry for being nitpicky, but primitive types and single-field structs with Copy types automatically get Copy. However, multi-field structs require you to be explicit about implementing Copy, encouraging you to carefully consider whether a more complex type should be treated as copyable.