### PR TITLE
Fix dead link to blog.acolyer.org

### DIFF
--- a/book/link2alias.json
+++ b/book/link2alias.json
@@ -1,5 +1,5 @@
 {
-  "https://blog.acolyer.org/2019/05/28/cheri-abi/": "f2u",
+  "https://web.archive.org/web/20240517051950/https://blog.acolyer.org/2019/05/28/cheri-abi/": "f2u",
   "https://code.visualstudio.com": "f6c",
   "https://crates.io": "f4q",
   "https://crates.io/crates/cargo-modules": "f2n",

--- a/book/src/03_ticket_v1/09_heap.md
+++ b/book/src/03_ticket_v1/09_heap.md
@@ -137,6 +137,6 @@ or [a custom allocator](https://docs.rs/dhat/latest/dhat/)) to inspect the heap 
 Heap memory will be reserved when you push data into it for the first time.
 
 [^equivalence]: The size of a pointer depends on the operating system too.
-In certain environments, a pointer is **larger** than a memory address (e.g. [CHERI](https://blog.acolyer.org/2019/05/28/cheri-abi/)).
+In certain environments, a pointer is **larger** than a memory address (e.g. [CHERI](https://web.archive.org/web/20240517051950/https://blog.acolyer.org/2019/05/28/cheri-abi/)).
 Rust makes the simplifying assumption that pointers are the same size as memory addresses,
 which is true for most modern systems you're likely to encounter.

--- a/site/_redirects
+++ b/site/_redirects
@@ -1,4 +1,4 @@
-/f2u https://blog.acolyer.org/2019/05/28/cheri-abi/
+/f2u https://web.archive.org/web/20240517051950/https://blog.acolyer.org/2019/05/28/cheri-abi/
 /f6c https://code.visualstudio.com
 /f4q https://crates.io
 /f2n https://crates.io/crates/cargo-modules


### PR DESCRIPTION
Was going through the course and found that this link no longer works, so I replaced it with the latest web archive of the original URL.