### PR TITLE
Fix typos in Markdown files

### DIFF
--- a/book/src/01_intro/00_welcome.md
+++ b/book/src/01_intro/00_welcome.md
@@ -25,7 +25,7 @@ to be delivered in a classroom setting, over 4 days: each attendee advances
 through the lessons at their own pace, with an experienced instructor providing
 guidance, answering questions and diving deeper into the topics as needed.\
 You can sign up for the next tutored session on [our website](https://ti.to/mainmatter/rust-from-scratch-jan-2025).
-If you'd like to organise a private session for your company, please [get in touch](https://mainmatter.com/contact/).
+If you'd like to organize a private session for your company, please [get in touch](https://mainmatter.com/contact/).
 
 You can also take the courses on your own, but we recommend you find a friend or
 a mentor to help you along the way should you get stuck. You can

--- a/book/src/02_basic_calculator/08_overflow.md
+++ b/book/src/02_basic_calculator/08_overflow.md
@@ -57,7 +57,7 @@ will give you -128 (=`i8::MIN`).
 ## `overflow-checks`
 
 Rust lets you, the developer, choose which approach to use when an integer overflow occurs.
-The behaviour is controlled by the `overflow-checks` profile setting.
+The behavior is controlled by the `overflow-checks` profile setting.
 
 If `overflow-checks` is set to `true`, Rust will **panic at runtime** when an integer operation overflows.
 If `overflow-checks` is set to `false`, Rust will **wrap around** when an integer operation overflows.
@@ -99,7 +99,7 @@ This is in line with the goals of the two profiles.\
 `release`, instead, is tuned for runtime performance: checking for overflows would slow down the program, so it
 prefers to wrap around.
 
-At the same time, having different behaviours for the two profiles can lead to subtle bugs.\
+At the same time, having different behaviors for the two profiles can lead to subtle bugs.\
 Our recommendation is to enable `overflow-checks` for both profiles: it's better to crash than to silently produce
 incorrect results. The runtime performance hit is negligible in most cases; if you're working on a performance-critical
 application, you can run benchmarks to decide if it's something you can afford.

--- a/book/src/02_basic_calculator/10_as_casting.md
+++ b/book/src/02_basic_calculator/10_as_casting.md
@@ -88,7 +88,7 @@ explore later in the course.
 
 ### Limitations
 
-Surprising behaviour is not the only downside of `as` casting.
+Surprising behavior is not the only downside of `as` casting.
 It is also fairly limited: you can only rely on `as` casting
 for primitive types and a few other special cases.\
 When working with composite types, you'll have to rely on
@@ -98,5 +98,5 @@ and [infallible](../04_traits/09_from.md)), which we'll explore later on.
 ## Further reading
 
 - Check out [Rust's official reference](https://doc.rust-lang.org/reference/expressions/operator-expr.html#numeric-cast)
-  to learn the precise behaviour of `as` casting for each source/target combination,
+  to learn the precise behavior of `as` casting for each source/target combination,
   as well as the exhaustive list of allowed conversions.

--- a/book/src/03_ticket_v1/00_intro.md
+++ b/book/src/03_ticket_v1/00_intro.md
@@ -1,4 +1,4 @@
-# Modelling A Ticket
+# Modeling A Ticket
 
 The first chapter should have given you a good grasp over some of Rust's primitive types, operators and
 basic control flow constructs.\

--- a/book/src/03_ticket_v1/01_struct.md
+++ b/book/src/03_ticket_v1/01_struct.md
@@ -64,7 +64,7 @@ let x = ticket.description;
 
 ## Methods
 
-We can attach behaviour to our structs by defining **methods**.\
+We can attach behavior to our structs by defining **methods**.\
 Using the `Ticket` struct as an example:
 
 ```rust

--- a/book/src/04_traits/05_trait_bounds.md
+++ b/book/src/04_traits/05_trait_bounds.md
@@ -2,8 +2,8 @@
 
 We've seen two use cases for traits so far:
 
-- Unlocking "built-in" behaviour (e.g. operator overloading)
-- Adding new behaviour to existing types (i.e. extension traits)
+- Unlocking "built-in" behavior (e.g. operator overloading)
+- Adding new behavior to existing types (i.e. extension traits)
 
 There's a third use case: **generic programming**.
 
@@ -120,8 +120,8 @@ help: consider restricting type parameter `T`
 
 Without trait bounds, the compiler doesn't know what `T` **can do**.\
 It doesn't know that `T` has an `is_even` method, and it doesn't know how to format `T` for printing.
-From the compiler point of view, a bare `T` has no behaviour at all.\
-Trait bounds restrict the set of types that can be used by ensuring that the behaviour required by the function
+From the compiler point of view, a bare `T` has no behavior at all.\
+Trait bounds restrict the set of types that can be used by ensuring that the behavior required by the function
 body is present.
 
 ## Syntax: inlining trait bounds

--- a/book/src/05_ticket_v2/00_intro.md
+++ b/book/src/05_ticket_v2/00_intro.md
@@ -1,4 +1,4 @@
-# Modelling A Ticket, pt. 2
+# Modeling A Ticket, pt. 2
 
 The `Ticket` struct we worked on in the previous chapters is a good start,
 but it still screams "I'm a beginner Rustacean!".

--- a/book/src/07_threads/13_without_channels.md
+++ b/book/src/07_threads/13_without_channels.md
@@ -11,7 +11,7 @@ Our first implementation of a multithreaded ticket store used:
 
 No locking of the state was necessary, since the server was the only one modifying the state. That's because
 the "inbox" channel naturally **serialized** incoming requests: the server would process them one by one.\
-We've already discussed the limitations of this approach when it comes to patching behaviour, but we didn't
+We've already discussed the limitations of this approach when it comes to patching behavior, but we didn't
 discuss the performance implications of the original design: the server could only process one request at a time,
 including reads.
 


### PR DESCRIPTION
I corrected various typos in Markdown files throughout the `book/src/` directory.

Changes include:
- Standardized 'organise' to 'organize'.
- Standardized 'behaviour' to 'behavior'.
- Standardized 'Modelling' to 'Modeling'.
- Other minor spelling corrections.

No typos were found in the Rust files within the `exercises/` directory.