### PR TITLE
Fix typo in 02_match

### DIFF
--- a/book/src/05_ticket_v2/02_match.md
+++ b/book/src/05_ticket_v2/02_match.md
@@ -70,7 +70,7 @@ match status {
 The `_` pattern matches anything that wasn't matched by the previous patterns.
 
 <div class="warning">
-By using this catch-all pattern, you _won't_ get the benefits of compiler-driven refactoring.\
+By using this catch-all pattern, you _won't_ get the benefits of compiler-driven refactoring.
 If you add a new enum variant, the compiler _won't_ tell you that you're not handling it.
 
 If you're keen on correctness, avoid using catch-alls. Leverage the compiler to re-examine all matching sites and determine how new enum variants should be handled.


### PR DESCRIPTION
<img width="899" height="154" alt="image" src="https://github.com/user-attachments/assets/d779fa4d-8afa-4cc0-b97b-8bc551d83aa9" />