### PR TITLE
feat(ci): Replace deprecated TeXLive action with working alternative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           echo "$PWD/pandoc-${PANDOC_VERSION}/bin" >> $GITHUB_PATH
         shell: bash
       - name: Setup TeX Live
-        uses: teatimeguest/setup-texlive-action@v3
+        uses: TeX-Live/setup-texlive-action@v3
         with:
           packages:
             scheme-basic
@@ -111,9 +111,9 @@ jobs:
         with:
           fail: true
           args: |
-            --exclude-loopback 
-            --require-https 
-            --no-progress 
+            --exclude-loopback
+            --require-https
+            --no-progress
             book/book/html/
       # Upload the HTML book as an artifact
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
**Description of Changes:**

This PR fixes the failing CI build by replacing the deprecated `teatimeguest/setup-texlive-action@v3` with the actively maintained `TeX-Live/setup-texlive-action@v3`.

**Changes made:**
- Updated `.github/workflows/ci.yml` line 59 to use `TeX-Live/setup-texlive-action@v3` instead of the deleted `teatimeguest/setup-texlive-action@v3`
- All existing TeXLive package configurations remain unchanged
- Maintains full API compatibility with existing workflow

**Aim/Goal of Changes:**

The primary goal is to restore the CI pipeline functionality by resolving the action lookup failure. The current workflow was failing with the error:

`Error: An action could not be found at the URI 'https://api.github.com/repos/teatimeguest/setup-texlive-action/tarball/ff7075d1802f73f131689d381f345a8dc5a5000'`

This change ensures:
- ✅ CI builds can run successfully 
- ✅ PDF and ePUB generation continues to work
- ✅ All TeXLive packages are installed correctly
- ✅ No breaking changes to existing functionality

**How to Test/Verify:**

1. **Verify CI Pipeline**: Push this branch and confirm the GitHub Actions workflow runs without the TeXLive action error
2. **Check Build Artifacts**: Ensure that all build artifacts are generated successfully:
   - HTML book output
   - PDF with cover (`100-exercises-to-learn-rust.pdf`)
   - Paperback PDF version
   - ePUB format
3. **Validate TeXLive Installation**: Confirm the `tlmgr --version` step succeeds
4. **Test Package Installation**: Verify all required TeXLive packages are installed correctly

**Expected behavior after fix:**
- CI workflow completes successfully without action resolution errors
- All existing TeXLive packages continue to be installed
- Book generation (HTML, PDF, ePUB) works as before

**Request for Review:**

Please review the changes for clarity, correctness and adherence to project goals. This is a straightforward replacement of a deprecated GitHub Action with its official successor, maintaining full backward compatibility while fixing the CI build failure.

**Additional Context:**

The `TeX-Live/setup-texlive-action@v3` is the official replacement maintained by the TeX-Live organization and is specifically documented as "a temp replacement for the deleted `teatimeguest/setup-texlive-action`". It uses the same input parameters and maintains identical functionality.