### PR TITLE
Fix private interface warnings in chapter 7

### DIFF
--- a/exercises/07_threads/09_bounded/src/lib.rs
+++ b/exercises/07_threads/09_bounded/src/lib.rs
@@ -38,7 +38,7 @@ enum Command {
     },
 }
 
-pub fn server(receiver: Receiver<Command>) {
+fn server(receiver: Receiver<Command>) {
     let mut store = TicketStore::new();
     loop {
         match receiver.recv() {

--- a/exercises/07_threads/10_patch/src/lib.rs
+++ b/exercises/07_threads/10_patch/src/lib.rs
@@ -63,7 +63,7 @@ enum Command {
     },
 }
 
-pub fn server(receiver: Receiver<Command>) {
+fn server(receiver: Receiver<Command>) {
     let mut store = TicketStore::new();
     loop {
         match receiver.recv() {

--- a/exercises/07_threads/11_locks/src/lib.rs
+++ b/exercises/07_threads/11_locks/src/lib.rs
@@ -60,7 +60,7 @@ enum Command {
     },
 }
 
-pub fn server(receiver: Receiver<Command>) {
+fn server(receiver: Receiver<Command>) {
     let mut store = TicketStore::new();
     loop {
         match receiver.recv() {

--- a/exercises/07_threads/12_rw_lock/src/lib.rs
+++ b/exercises/07_threads/12_rw_lock/src/lib.rs
@@ -59,7 +59,7 @@ enum Command {
     },
 }
 
-pub fn server(receiver: Receiver<Command>) {
+fn server(receiver: Receiver<Command>) {
     let mut store = TicketStore::new();
     loop {
         match receiver.recv() {


### PR DESCRIPTION
Exercises 9 to 12 of chapter 7, have `private_interface` warnings that remain after solving them that come from declaring the `server` function as public and having the type declaration of it's `receiver` argument as private.