### PR TITLE
Remove book.multilingual

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Luca Palmieri"]
 language = "en"
-multilingual = false
 src = "src"
 title = "100 Exercises To Learn Rust"
 


### PR DESCRIPTION
The key `book.multilingual` was recently removed (https://github.com/rust-lang/mdBook/pull/2775) and the book does not build any more. After removing the key, another error popped up:

```
Unable to parse the input
 WARN Error writing the RenderContext to the backend, Broken pipe (os error 32)
ERROR The "exercise-linker" preprocessor exited unsuccessfully with exit status: 1 status
Error: Process completed with exit code 101.
```