### PR TITLE
Extend test in main_06_05

### DIFF
--- a/exercises/06_ticket_management/05_iter/src/lib.rs
+++ b/exercises/06_ticket_management/05_iter/src/lib.rs
@@ -62,5 +62,6 @@ mod tests {
         let tickets: Vec<&Ticket> = store.iter().collect();
         let tickets2: Vec<&Ticket> = store.iter().collect();
         assert_eq!(tickets, tickets2);
+        assert_eq!(store.iter().len(), 2);
     }
 }


### PR DESCRIPTION
`assert_eq!(tickets, tickets2);` test is not enough as task could be passed with incorrect solution like

```
pub fn iter(&self) -> std::slice::Iter<Ticket> {
    [].iter() // must be self.tickets.iter()
}
```
So there's a need to also validate `store.iter().len()`.