### PR TITLE
Remove deprecated "multilingual" field from book.toml

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Luca Palmieri"]
 language = "en"
-multilingual = false
 src = "src"
 title = "100 Exercises To Learn Rust"
 


### PR DESCRIPTION
## Summary

- Remove the deprecated `multilingual = false` line from `book/book.toml`
- Fixes #332 — newer versions of mdbook removed this field, causing a TOML parse error on `mdbook build` / `mdbook serve`

## Test plan

- [x] Run `mdbook build` in the `book/` directory — should complete without parse errors
- [x] Run `mdbook serve` — book should render correctly

/cc @tupe12334

🤖 Generated with [Claude Code](https://claude.com/claude-code)