### PR TITLE
Match leaking memory page title to one on sidebar menu

### DIFF
--- a/book/src/07_threads/03_leak.md
+++ b/book/src/07_threads/03_leak.md
@@ -1,4 +1,4 @@
-# Leaking data
+# Leaking memory
 
 The main concern around passing references to spawned threads is use-after-free bugs:
 accessing data using a pointer to a memory region that's already been freed/de-allocated.\


### PR DESCRIPTION
Sidebar menu has it as `Leaking memory`,  while the page title has it as `Leaking data`.

Kept the text body as is, but I'm wondering whether it wouldn't make sense to also change `Data leakage is process-scoped` and `Leaking data is dangerous` accordingly - let me know