### PR TITLE
Issue #326: Add negative test case (invalid input -> `Err` result)

### DIFF
--- a/exercises/05_ticket_v2/13_try_from/src/lib.rs
+++ b/exercises/05_ticket_v2/13_try_from/src/lib.rs
@@ -23,6 +23,12 @@ mod tests {
 
         let status = Status::try_from("Done".to_string()).unwrap();
         assert_eq!(status, Status::Done);
+
+        let empty = String::new();
+        assert!(Status::try_from(empty).is_err());
+
+        let invalid = "InValid".to_string();
+        assert!(Status::try_from(invalid).is_err());
     }
 
     #[test]
@@ -35,5 +41,8 @@ mod tests {
 
         let status = Status::try_from("done").unwrap();
         assert_eq!(status, Status::Done);
+
+        assert!(Status::try_from("").is_err());
+        assert!(Status::try_from("invalid").is_err());
     }
 }


### PR DESCRIPTION
Pull request for issue #326 

Verify that TryFrom trait properly handles invalid input. Rather than `panic()`ing, this case ought to return `Result::Err(...)` .