### PR TITLE
Remove dangling references to externalized repos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,6 @@
 members = [
   "exercises/*/*",
   "helpers/common",
-  "helpers/mdbook-exercise-linker",
-  "helpers/mdbook-link-shortener",
   "helpers/ticket_fields",
 ]
 resolver = "2"


### PR DESCRIPTION
#346 removed these to their own repos but left dangling references in `Cargo.toml`

Fixes #347 